### PR TITLE
Use AuthenticationCompletionException if the negotiation can not continue

### DIFF
--- a/runtime/src/main/java/io/quarkiverse/kerberos/runtime/KerberosAuthenticationMechanism.java
+++ b/runtime/src/main/java/io/quarkiverse/kerberos/runtime/KerberosAuthenticationMechanism.java
@@ -67,8 +67,6 @@ public class KerberosAuthenticationMechanism implements HttpAuthenticationMechan
 
     @Override
     public Set<Class<? extends AuthenticationRequest>> getCredentialTypes() {
-        // The service ticket can be viewed as an Spnego token.
-        // TODO: However it will be easier to deal with a Negotiate specific request object.
         return Collections.singleton(NegotiateAuthenticationRequest.class);
     }
 
@@ -88,7 +86,7 @@ public class KerberosAuthenticationMechanism implements HttpAuthenticationMechan
         int idx = headerValue.indexOf(' ');
         final String scheme = idx > 0 ? headerValue.substring(0, idx) : null;
 
-        if (!NEGOTIATE_SCHEME.equals(scheme)) {
+        if (!NEGOTIATE_SCHEME.equalsIgnoreCase(scheme)) {
             return null;
         }
 

--- a/runtime/src/main/java/io/quarkiverse/kerberos/runtime/KerberosIdentityProvider.java
+++ b/runtime/src/main/java/io/quarkiverse/kerberos/runtime/KerberosIdentityProvider.java
@@ -150,13 +150,13 @@ public class KerberosIdentityProvider implements IdentityProvider<NegotiateAuthe
                     }
                 } catch (LoginException ex) {
                     LOG.debugf("Login exception: %s", ex.getMessage());
-                    throw new RuntimeException(ex);
+                    throw new AuthenticationCompletionException(ex);
                 } catch (GSSException ex) {
                     LOG.debugf("GSS exception: %s", ex.getMessage());
-                    throw new AuthenticationFailedException(ex);
+                    throw new AuthenticationCompletionException(ex);
                 } catch (PrivilegedActionException ex) {
                     LOG.debugf("PrivilegedAction exception: %s", ex.getMessage());
-                    throw new RuntimeException(ex);
+                    throw new AuthenticationCompletionException(ex);
                 }
             }
 
@@ -190,7 +190,7 @@ public class KerberosIdentityProvider implements IdentityProvider<NegotiateAuthe
 
         GSSManager gssManager = GSSManager.getInstance();
         if (gssManager == null) {
-            throw new IllegalStateException("GSSManager was null");
+            throw new AuthenticationCompletionException("GSSManager was null");
         }
 
         GSSName gssService = gssManager.createName(completeServicePrincipalName, null);


### PR DESCRIPTION
It will avoid some possible loops with the challenge, and 500s instead of 401s as it is probably better report 401 if Login fails for whatever reasons