### PR TITLE
Simplify the client test code

### DIFF
--- a/deployment/src/test/java/io/quarkiverse/kerberos/test/SpnegoAuthenticationTestCase.java
+++ b/deployment/src/test/java/io/quarkiverse/kerberos/test/SpnegoAuthenticationTestCase.java
@@ -19,30 +19,18 @@
 package io.quarkiverse.kerberos.test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
-import java.nio.charset.StandardCharsets;
-import java.security.PrivilegedExceptionAction;
-import java.util.Base64;
 import java.util.function.Supplier;
 
-import javax.security.auth.Subject;
-
-import org.apache.commons.lang.ArrayUtils;
 import org.hamcrest.Matchers;
-import org.ietf.jgss.GSSContext;
-import org.ietf.jgss.GSSManager;
-import org.ietf.jgss.GSSName;
-import org.ietf.jgss.Oid;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.quarkiverse.kerberos.test.utils.KerberosKDCTestResource;
+import io.quarkiverse.kerberos.test.utils.KerberosTestClient;
 import io.quarkus.test.QuarkusUnitTest;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.restassured.RestAssured;
@@ -64,12 +52,7 @@ public class SpnegoAuthenticationTestCase {
                 }
             });
 
-    private static Oid SPNEGO;
-
-    @BeforeAll
-    public static void setup() throws Exception {
-        SPNEGO = new Oid("1.3.6.1.5.5.2");
-    }
+    KerberosTestClient kerberosTestClient = new KerberosTestClient();
 
     @Test
     public void testSpnegoSuccess() throws Exception {
@@ -80,56 +63,8 @@ public class SpnegoAuthenticationTestCase {
                 .header(HttpHeaderNames.WWW_AUTHENTICATE.toString());
         assertEquals(NEGOTIATE, header);
 
-        Subject clientSubject = KerberosKDCTestResource.login("jduke", "theduke".toCharArray());
-
-        Subject.doAs(clientSubject, new PrivilegedExceptionAction<Void>() {
-
-            @Override
-            public Void run() throws Exception {
-                GSSManager gssManager = GSSManager.getInstance();
-                GSSName serverName = gssManager.createName("HTTP/localhost", null);
-
-                GSSContext context = gssManager.createContext(serverName, SPNEGO, null, GSSContext.DEFAULT_LIFETIME);
-
-                byte[] token = new byte[0];
-
-                boolean gotOur200 = false;
-                while (!context.isEstablished()) {
-                    token = context.initSecContext(token, 0, token.length);
-
-                    if (token != null && token.length > 0) {
-                        var result = RestAssured.given()
-                                .header(HttpHeaderNames.AUTHORIZATION.toString(),
-                                        NEGOTIATE + " " + Base64.getEncoder().encodeToString(token))
-                                .get("/identity").then();
-
-                        String header = result.extract().header(HttpHeaderNames.WWW_AUTHENTICATE.toString());
-                        if (header != null) {
-
-                            byte[] headerBytes = header.getBytes(StandardCharsets.US_ASCII);
-                            // FlexBase64.decode() returns byte buffer, which can contain backend array of greater size.
-                            // when on such ByteBuffer is called array(), it returns the underlying byte array including the 0 bytes
-                            // at the end, which makes the token invalid. => using Base64 mime decoder, which returnes directly properly sized byte[].
-                            token = Base64.getMimeDecoder().decode(
-                                    ArrayUtils.subarray(headerBytes, NEGOTIATE.toString().length() + 1, headerBytes.length));
-                        }
-
-                        if (result.extract().statusCode() == 200) {
-                            result.body(Matchers.is("jduke"));
-                            gotOur200 = true;
-                        } else if (result.extract().statusCode() == 401) {
-                            assertTrue(header != null, "We did get a header.");
-                        } else {
-                            fail(String.format("Unexpected status code %d", result.extract().statusCode()));
-                        }
-                    }
-                }
-
-                assertTrue(gotOur200);
-                assertTrue(context.isEstablished());
-                return null;
-            }
-        });
+        var result = kerberosTestClient.get("/identity", "jduke", "theduke");
+        result.body(Matchers.is("jduke"));
     }
 
 }

--- a/integration-tests/src/test/java/io/quarkiverse/kerberos/it/KerberosResourceTestCase.java
+++ b/integration-tests/src/test/java/io/quarkiverse/kerberos/it/KerberosResourceTestCase.java
@@ -19,26 +19,13 @@
 package io.quarkiverse.kerberos.it;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
-import java.nio.charset.StandardCharsets;
-import java.security.PrivilegedExceptionAction;
-import java.util.Base64;
-
-import javax.security.auth.Subject;
-
-import org.apache.commons.lang.ArrayUtils;
 import org.hamcrest.Matchers;
-import org.ietf.jgss.GSSContext;
-import org.ietf.jgss.GSSManager;
-import org.ietf.jgss.GSSName;
-import org.ietf.jgss.Oid;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.quarkiverse.kerberos.test.utils.KerberosKDCTestResource;
+import io.quarkiverse.kerberos.test.utils.KerberosTestClient;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
@@ -53,12 +40,7 @@ import io.restassured.RestAssured;
 public class KerberosResourceTestCase {
     public static final String NEGOTIATE = "Negotiate";
 
-    private static Oid SPNEGO;
-
-    @BeforeAll
-    public static void startServers() throws Exception {
-        SPNEGO = new Oid("1.3.6.1.5.5.2");
-    }
+    KerberosTestClient kerberosTestClient = new KerberosTestClient();
 
     @Test
     public void testSpnegoSuccess() throws Exception {
@@ -69,56 +51,8 @@ public class KerberosResourceTestCase {
                 .header(HttpHeaderNames.WWW_AUTHENTICATE.toString());
         assertEquals(NEGOTIATE, header);
 
-        Subject clientSubject = KerberosKDCTestResource.login("jduke", "theduke".toCharArray());
-
-        Subject.doAs(clientSubject, new PrivilegedExceptionAction<Void>() {
-
-            @Override
-            public Void run() throws Exception {
-                GSSManager gssManager = GSSManager.getInstance();
-                GSSName serverName = gssManager.createName("HTTP/localhost", null);
-
-                GSSContext context = gssManager.createContext(serverName, SPNEGO, null, GSSContext.DEFAULT_LIFETIME);
-
-                byte[] token = new byte[0];
-
-                boolean gotOur200 = false;
-                while (!context.isEstablished()) {
-                    token = context.initSecContext(token, 0, token.length);
-
-                    if (token != null && token.length > 0) {
-                        var result = RestAssured.given()
-                                .header(HttpHeaderNames.AUTHORIZATION.toString(),
-                                        NEGOTIATE + " " + Base64.getEncoder().encodeToString(token))
-                                .get().then();
-
-                        String header = result.extract().header(HttpHeaderNames.WWW_AUTHENTICATE.toString());
-                        if (header != null) {
-
-                            byte[] headerBytes = header.getBytes(StandardCharsets.US_ASCII);
-                            // FlexBase64.decode() returns byte buffer, which can contain backend array of greater size.
-                            // when on such ByteBuffer is called array(), it returns the underlying byte array including the 0 bytes
-                            // at the end, which makes the token invalid. => using Base64 mime decoder, which returnes directly properly sized byte[].
-                            token = Base64.getMimeDecoder().decode(
-                                    ArrayUtils.subarray(headerBytes, NEGOTIATE.toString().length() + 1, headerBytes.length));
-                        }
-
-                        if (result.extract().statusCode() == 200) {
-                            result.body(Matchers.is("jduke jduke@QUARKUS.IO QUARKUS.IO"));
-                            gotOur200 = true;
-                        } else if (result.extract().statusCode() == 401) {
-                            assertTrue(header != null, "We did get a header.");
-                        } else {
-                            fail(String.format("Unexpected status code %d", result.extract().statusCode()));
-                        }
-                    }
-                }
-
-                assertTrue(gotOur200);
-                assertTrue(context.isEstablished());
-                return null;
-            }
-        });
+        var result = kerberosTestClient.get("jduke", "theduke");
+        result.body(Matchers.is("jduke jduke@QUARKUS.IO QUARKUS.IO"));
     }
 
 }

--- a/test-util/pom.xml
+++ b/test-util/pom.xml
@@ -21,5 +21,9 @@
             <groupId>io.quarkiverse.kerberos</groupId>
             <artifactId>quarkus-kerberos</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/test-util/src/main/java/io/quarkiverse/kerberos/test/utils/KerberosTestClient.java
+++ b/test-util/src/main/java/io/quarkiverse/kerberos/test/utils/KerberosTestClient.java
@@ -1,0 +1,93 @@
+package io.quarkiverse.kerberos.test.utils;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.nio.charset.StandardCharsets;
+import java.security.PrivilegedExceptionAction;
+import java.util.Base64;
+
+import javax.security.auth.Subject;
+
+import org.apache.commons.lang.ArrayUtils;
+import org.ietf.jgss.GSSContext;
+import org.ietf.jgss.GSSException;
+import org.ietf.jgss.GSSManager;
+import org.ietf.jgss.GSSName;
+import org.ietf.jgss.Oid;
+
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.restassured.RestAssured;
+import io.restassured.response.ValidatableResponse;
+
+public class KerberosTestClient {
+    public static final String NEGOTIATE = "Negotiate";
+
+    public ValidatableResponse get(String principalName, String principalPassword) {
+        return get("/", principalName, principalPassword);
+    }
+
+    public ValidatableResponse get(String path, String principalName, String principalPassword) {
+        try {
+            Subject clientSubject = KerberosKDCTestResource.login(principalName, principalPassword.toCharArray());
+
+            return Subject.doAs(clientSubject, new PrivilegedExceptionAction<ValidatableResponse>() {
+
+                @Override
+                public ValidatableResponse run() throws Exception {
+                    GSSManager gssManager = GSSManager.getInstance();
+                    GSSName serverName = gssManager.createName("HTTP/localhost", null);
+
+                    GSSContext context = gssManager.createContext(serverName, createSpnegoOid(), null,
+                            GSSContext.DEFAULT_LIFETIME);
+
+                    byte[] token = new byte[0];
+
+                    while (!context.isEstablished()) {
+                        token = context.initSecContext(token, 0, token.length);
+
+                        if (token != null && token.length > 0) {
+                            ValidatableResponse result = RestAssured.given()
+                                    .header(HttpHeaderNames.AUTHORIZATION.toString(),
+                                            NEGOTIATE + " " + Base64.getEncoder().encodeToString(token))
+                                    .get(path).then();
+
+                            String header = result.extract().header(HttpHeaderNames.WWW_AUTHENTICATE.toString());
+                            if (header != null) {
+
+                                byte[] headerBytes = header.getBytes(StandardCharsets.US_ASCII);
+                                // FlexBase64.decode() returns byte buffer, which can contain backend array of greater size.
+                                // when on such ByteBuffer is called array(), it returns the underlying byte array including the 0 bytes
+                                // at the end, which makes the token invalid. => using Base64 mime decoder, which returnes directly properly sized byte[].
+                                token = Base64.getMimeDecoder().decode(
+                                        ArrayUtils.subarray(headerBytes, NEGOTIATE.toString().length() + 1,
+                                                headerBytes.length));
+                            }
+
+                            if (result.extract().statusCode() == 200) {
+                                return result;
+                            } else if (result.extract().statusCode() == 401) {
+                                assertTrue(header != null, "We did get a header.");
+                            } else {
+                                fail(String.format("Unexpected status code %d", result.extract().statusCode()));
+                            }
+                        }
+                    }
+                    fail("Negotiation failure");
+                    return null;
+                }
+            });
+        } catch (Exception ex) {
+            fail(String.format("Unexpected exception: ", ex.getMessage()));
+        }
+        return null;
+    }
+
+    private Oid createSpnegoOid() {
+        try {
+            return new Oid("1.3.6.1.5.5.2");
+        } catch (GSSException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+}

--- a/test-util/src/main/java/io/quarkiverse/kerberos/test/utils/TestSubjectFactory.java
+++ b/test-util/src/main/java/io/quarkiverse/kerberos/test/utils/TestSubjectFactory.java
@@ -1,21 +1,7 @@
 package io.quarkiverse.kerberos.test.utils;
 
-import static javax.security.auth.login.AppConfigurationEntry.LoginModuleControlFlag.REQUIRED;
-
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
-
 import javax.enterprise.context.ApplicationScoped;
 import javax.security.auth.Subject;
-import javax.security.auth.callback.Callback;
-import javax.security.auth.callback.CallbackHandler;
-import javax.security.auth.callback.NameCallback;
-import javax.security.auth.callback.PasswordCallback;
-import javax.security.auth.callback.UnsupportedCallbackException;
-import javax.security.auth.login.AppConfigurationEntry;
-import javax.security.auth.login.Configuration;
-import javax.security.auth.login.LoginContext;
 import javax.security.auth.login.LoginException;
 
 import io.quarkiverse.kerberos.ServicePrincipalSubjectFactory;
@@ -23,89 +9,13 @@ import io.quarkiverse.kerberos.ServicePrincipalSubjectFactory;
 @ApplicationScoped
 public class TestSubjectFactory implements ServicePrincipalSubjectFactory {
 
-    private static final boolean IS_IBM = System.getProperty("java.vendor").contains("IBM");
-
     @Override
     public Subject getSubjectForServicePrincipal(String servicePrincipalName) {
         try {
-            return login(servicePrincipalName, "servicepwd".toCharArray());
+            return KerberosKDCTestResource.login(servicePrincipalName, "servicepwd".toCharArray());
         } catch (LoginException e) {
             throw new RuntimeException(e);
         }
     }
 
-    static Subject login(final String userName, final char[] password) throws LoginException {
-        Subject theSubject = new Subject();
-        CallbackHandler cbh = new UsernamePasswordCBH(userName, password);
-        LoginContext lc = new LoginContext("KDC", theSubject, cbh, createJaasConfiguration());
-        lc.login();
-
-        return theSubject;
-    }
-
-    static class UsernamePasswordCBH implements CallbackHandler {
-
-        /*
-         * Note: We use CallbackHandler implementations like this in test cases as test cases need to run unattended, a true
-         * CallbackHandler implementation should interact directly with the current user to prompt for the username and
-         * password.
-         *
-         * i.e. In a client app NEVER prompt for these values in advance and provide them to a CallbackHandler like this.
-         */
-
-        private final String username;
-        private final char[] password;
-
-        private UsernamePasswordCBH(final String username, final char[] password) {
-            this.username = username;
-            this.password = password;
-        }
-
-        @Override
-        public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
-            for (Callback current : callbacks) {
-                if (current instanceof NameCallback) {
-                    NameCallback ncb = (NameCallback) current;
-                    ncb.setName(username);
-                } else if (current instanceof PasswordCallback) {
-                    PasswordCallback pcb = (PasswordCallback) current;
-                    pcb.setPassword(password);
-                } else {
-                    throw new UnsupportedCallbackException(current);
-                }
-            }
-
-        }
-
-    }
-
-    private static Configuration createJaasConfiguration() {
-        return new Configuration() {
-
-            @Override
-            public AppConfigurationEntry[] getAppConfigurationEntry(String name) {
-                if (!"KDC".equals(name)) {
-                    throw new IllegalArgumentException("Unexpected name '" + name + "'");
-                }
-
-                AppConfigurationEntry[] entries = new AppConfigurationEntry[1];
-                Map<String, Object> options = new HashMap<>();
-                options.put("debug", "true");
-                options.put("refreshKrb5Config", "true");
-
-                if (IS_IBM) {
-                    options.put("noAddress", "true");
-                    options.put("credsType", "both");
-                    entries[0] = new AppConfigurationEntry("com.ibm.security.auth.module.Krb5LoginModule", REQUIRED, options);
-                } else {
-                    options.put("storeKey", "true");
-                    options.put("isInitiator", "true");
-                    entries[0] = new AppConfigurationEntry("com.sun.security.auth.module.Krb5LoginModule", REQUIRED, options);
-                }
-
-                return entries;
-            }
-
-        };
-    }
 }


### PR DESCRIPTION
`KerberosTestClient` is added, so far it handles `get` but it can be easily extended to support more variations with `post`, etc, we can also use it to pick up the dev services properties in the future as needed (similarly to how it is done for Keycloak Dev Services).

The next step, after #9 is also merged, is to complete `KerberosDevModeTest` and finally doc all the test options