### PR TITLE
Update DevMode test to use the DevServices container

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/kerberos/deployment/devservices/KerberosDevServicesProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/kerberos/deployment/devservices/KerberosDevServicesProcessor.java
@@ -81,12 +81,12 @@ public class KerberosDevServicesProcessor {
         DevServicesConfig currentDevServicesConfiguration = config.devservices;
         // Figure out if we need to shut down and restart any existing Kerberos container
         // if not and the Kerberos container has already started we just return
-        boolean restartRequired = false;
+        boolean restartRequired = !currentDevServicesConfiguration.equals(capturedDevServicesConfiguration);
+        if (!restartRequired) {
+            return existingDevServiceConfig;
+        }
+        ;
         if (closeables != null) {
-            restartRequired = !currentDevServicesConfiguration.equals(capturedDevServicesConfiguration);
-            if (!restartRequired) {
-                return existingDevServiceConfig;
-            }
             for (Closeable closeable : closeables) {
                 try {
                     closeable.close();

--- a/deployment/src/test/java/io/quarkiverse/kerberos/test/SpnegoAuthenticationDevModeTestCase.java
+++ b/deployment/src/test/java/io/quarkiverse/kerberos/test/SpnegoAuthenticationDevModeTestCase.java
@@ -9,13 +9,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.netty.handler.codec.http.HttpHeaderNames;
-import io.quarkiverse.kerberos.test.utils.KerberosKDCTestResource;
 import io.quarkiverse.kerberos.test.utils.KerberosTestClient;
 import io.quarkus.test.QuarkusDevModeTest;
-import io.quarkus.test.common.QuarkusTestResource;
 import io.restassured.RestAssured;
 
-@QuarkusTestResource(KerberosKDCTestResource.class)
 public class SpnegoAuthenticationDevModeTestCase {
     public static final String NEGOTIATE = "Negotiate";
 
@@ -40,12 +37,12 @@ public class SpnegoAuthenticationDevModeTestCase {
                 .header(HttpHeaderNames.WWW_AUTHENTICATE.toString());
         assertEquals(NEGOTIATE, header);
 
-        var result = kerberosTestClient.get("/identity", "jduke", "theduke");
+        var result = kerberosTestClient.get("/identity", "alice", "alice");
         result.statusCode(401);
 
         test.modifyResourceFile("application.properties", s -> s.replace("QUARKUSDEV.IO", "QUARKUS.IO"));
 
-        result = kerberosTestClient.get("/identity", "jduke", "theduke");
-        result.statusCode(200).body(Matchers.is("jduke"));
+        result = kerberosTestClient.get("/identity", "alice", "alice");
+        result.statusCode(200).body(Matchers.is("alice"));
     }
 }

--- a/deployment/src/test/resources/application-dev-mode.properties
+++ b/deployment/src/test/resources/application-dev-mode.properties
@@ -1,2 +1,2 @@
-quarkus.kerberos.devservices.enabled=false
+quarkus.kerberos.devservices.realm=QUARKUS.IO
 quarkus.kerberos.service-principal-realm=QUARKUSDEV.IO


### PR DESCRIPTION
It is related to #12 but not addresses it completely.

@stuartwdouglas, I had to move a `restartRequired` check out of the `if (closeables != null)` because there are 2 tests in `development` which use `DevServices`, `SpnegoAuthenticationTestCase` and now  `SpnegoAuthenticationDevModeTestCase` - the 2nd one uses a different configuration but by the time it starts the `closeables` created by `SpnegoAuthenticationTestCase` is null but since `java.security.krb5.conf` set by `SpnegoAuthenticationTestCase` is still around, the new container is not started and `SpnegoAuthenticationDevModeTestCase` fails.  

But now, since the static captured configuration keeps `SpnegoAuthenticationTestCase` 's one - it is possible to detect a restart is required, and thus, despite the system property pointing to the config file is already being set, the container is starting.

Note the actual test works because with

```
quarkus.kerberos.devservices.realm=QUARKUS.IO
quarkus.kerberos.service-principal-realm=QUARKUSDEV.IO
```
the Kerberos configuration contains `QUARKUS.IO` but `KerberosIdentityProvider` will attempt to use `HTTP/localhost@QUARKUSDEV.IO` - `401`, and next after replacing `QUARKUSDEV.IO` with `QUARKUS.IO` only the Quarkus endpoint is restarted but not the dev services container (since the dev services properties remain unchanged), so all works fine in the end and it is `200`.

But if I do

```
quarkus.kerberos.devservices.realm=QUARKUSDEV.IO
quarkus.kerberos.service-principal-realm=QUARKUS.IO
```

then, after replacing `QUARKUSDEV.IO` with `QUARKUS.IO`, the dev services container is also restarted, new Kerberos config with a different realm is created and I suspect the system properties are not helping as it looks like either the client or server is caching something. But as far simulating the failures is concerned it does not really matter if the devservices container is restarted or not, so it is not a big problem
 

```