### PR TITLE
Improve consistency of Antora modules

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,5 +1,5 @@
 name: quarkus-kerberos
-title: Quarkus - Kerberos
+title: Quarkus Kerberos
 version: dev
 nav:
   - modules/ROOT/nav.adoc


### PR DESCRIPTION
Most of the modules don't have a dash here: https://quarkiverse.github.io/quarkiverse-docs/index/index/index.html .

It will allow them to be properly sorted.